### PR TITLE
新規投稿画面で、カレンダー日程選択後に別の日程を選択した時、前回選択日程の試合が残らないようにしました

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -36,6 +36,7 @@ $("#datepicker").datepicker({
 
   //成功処理を記述
   .done(function(data) {
+    $(".game-select option").remove();
     $(data).each(function(i,game) {
       $(".game-select").append(
         `<option>${game.id}</option>`


### PR DESCRIPTION
Closes #62 